### PR TITLE
First preparations for release 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ serde = { version = "1.0", default-features = false }
 serde_test = "1.0.176"
 
 [features]
-default = []
+# From/Into implementation to `heapless::Vec<u8, N>`
+"heapless-0.8" = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,5 @@ edition = "2021"
 heapless = { version = "0.8", default-features = false }
 serde = { version = "1.0", default-features = false }
 
-[dependencies.serde_cbor]
-version = "0.11.0"
-default-features = false
-optional = true
-
-[features]
-cbor = ["serde_cbor"]
-
 [dev-dependencies]
 serde_test = "1.0.176"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ serde = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0.176"
+
+[features]
+default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ use core::{
     fmt::{self, Debug},
     hash::{Hash, Hasher},
     ops::{Deref, DerefMut},
-    ptr,
 };
 
 use heapless::Vec;
@@ -20,7 +19,7 @@ use serde::{
     ser::{Serialize, Serializer},
 };
 
-#[derive(Clone, Default, Eq)]
+#[derive(Clone, Default, Eq, Ord)]
 pub struct Bytes<const N: usize> {
     bytes: Vec<u8, N>,
 }
@@ -36,84 +35,150 @@ impl<const N: usize> From<Vec<u8, N>> for Bytes<N> {
     }
 }
 
+impl<const N: usize> From<Bytes<N>> for Vec<u8, N> {
+    fn from(value: Bytes<N>) -> Self {
+        value.bytes
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8]> for Bytes<N> {
+    type Error = ();
+    fn try_from(value: &[u8]) -> Result<Self, ()> {
+        Ok(Self {
+            bytes: Vec::from_slice(value)?,
+        })
+    }
+}
+
 impl<const N: usize> Bytes<N> {
     /// Construct a new, empty `Bytes<N>`.
     pub fn new() -> Self {
         Bytes::from(Vec::new())
     }
 
-    /// Unwraps the Vec<u8, N>, same as `into_vec`.
-    pub fn into_inner(self) -> Vec<u8, N> {
-        self.bytes
+    pub fn as_ptr(&self) -> *const u8 {
+        self.bytes.as_ptr()
     }
 
-    /// Unwraps the Vec<u8, N>, same as `into_inner`.
-    pub fn into_vec(self) -> Vec<u8, N> {
-        self.bytes
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.bytes.as_mut_ptr()
     }
 
-    /// Returns an immutable slice view.
-    // Add as inherent method as it's annoying to import AsSlice.
     pub fn as_slice(&self) -> &[u8] {
-        self.bytes.as_ref()
+        self.bytes.as_slice()
     }
-
-    /// Returns a mutable slice view.
-    // Add as inherent method as it's annoying to import AsSlice.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        self.bytes.as_mut()
+        self.bytes.as_mut_slice()
     }
 
-    /// Low-noise conversion between lengths.
-    ///
-    /// We can't implement TryInto since it would clash with blanket implementations.
-    pub fn try_convert_into<const M: usize>(&self) -> Result<Bytes<M>, ()> {
-        Bytes::<M>::from_slice(self)
+    pub const fn capacity(&self) -> usize {
+        self.bytes.capacity()
     }
 
-    // pub fn try_from_slice(slice: &[u8]) -> core::result::Result<Self, ()> {
-    //     let mut bytes = Vec::<u8, N>::new();
-    //     bytes.extend_from_slice(slice)?;
-    //     Ok(Self::from(bytes))
-    // }
-
-    pub fn from_slice(slice: &[u8]) -> core::result::Result<Self, ()> {
-        let mut bytes = Vec::<u8, N>::new();
-        bytes.extend_from_slice(slice)?;
-        Ok(Self::from(bytes))
+    pub fn clear(&mut self) {
+        self.bytes.clear()
     }
 
-    /// Some APIs offer an interface of the form `f(&mut [u8]) -> Result<usize, E>`,
-    /// with the contract that the Ok-value signals how many bytes were written.
-    ///
-    /// This constructor allows wrapping such interfaces in a more ergonomic way,
-    /// returning a Bytes willed using `f`.
-    ///
-    /// It seems it's not possible to do this as an actual `TryFrom` implementation.
-    pub fn try_from<E>(
-        f: impl FnOnce(&mut [u8]) -> core::result::Result<usize, E>,
-    ) -> core::result::Result<Self, E> {
-        let mut data = Self::new();
-        data.resize_to_capacity();
-        let result = f(&mut data);
-
-        result.map(|count| {
-            data.resize_default(count).unwrap();
-            data
-        })
+    #[deprecated(note = "Panics when out of capacity")]
+    pub fn extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
+        self.bytes.extend(iter)
     }
 
-    // pub fn try_from<'a, E>(
-    //     f: impl FnOnce(&'a mut [u8]) -> core::result::Result<&'a mut [u8], E>
-    // )
-    //     -> core::result::Result<Self, E>
-    // {
+    pub fn extend_from_slice(&mut self, other: &[u8]) -> Result<(), ()> {
+        self.bytes.extend_from_slice(other)
+    }
+
+    pub fn pop(&mut self) -> Option<u8> {
+        self.bytes.pop()
+    }
+
+    pub fn push(&mut self, byte: u8) -> Result<(), ()> {
+        self.bytes.push(byte).map_err(drop)
+    }
+
+    pub unsafe fn pop_unchecked(&mut self) -> u8 {
+        unsafe { self.bytes.pop_unchecked() }
+    }
+
+    pub unsafe fn push_unchecked(&mut self, byte: u8) {
+        unsafe {
+            self.bytes.push_unchecked(byte);
+        }
+    }
+
+    pub fn truncate(&mut self, len: usize) {
+        self.bytes.truncate(len)
+    }
+
+    pub fn resize(&mut self, new_len: usize, value: u8) -> Result<(), ()> {
+        self.bytes.resize(new_len, value)
+    }
+
+    pub fn resize_zero(&mut self, new_len: usize) -> Result<(), ()> {
+        self.bytes.resize_default(new_len)
+    }
+
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        self.bytes.set_len(new_len)
+    }
+
+    pub fn swap_remove(&mut self, index: usize) -> u8 {
+        self.bytes.swap_remove(index)
+    }
+
+    pub unsafe fn swap_remove_unchecked(&mut self, index: usize) -> u8 {
+        unsafe { self.bytes.swap_remove_unchecked(index) }
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.bytes.is_full()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    pub fn starts_with(&self, needle: &[u8]) -> bool {
+        self.bytes.starts_with(needle)
+    }
+    pub fn ends_with(&self, needle: &[u8]) -> bool {
+        self.bytes.ends_with(needle)
+    }
+
+    pub fn insert(&mut self, index: usize, value: u8) -> Result<(), ()> {
+        self.bytes.insert(index, value).map_err(drop)
+    }
+
+    pub fn remove(&mut self, index: usize) -> u8 {
+        self.bytes.remove(index)
+    }
+
+    pub fn retain(&mut self, f: impl FnMut(&u8) -> bool) {
+        self.bytes.retain(f)
+    }
+    pub fn retain_mut(&mut self, f: impl FnMut(&mut u8) -> bool) {
+        self.bytes.retain_mut(f)
+    }
+}
+
+impl<const N: usize> Bytes<N> {
+    // /// Some APIs offer an interface of the form `f(&mut [u8]) -> Result<usize, E>`,
+    // /// with the contract that the Ok-value signals how many bytes were written.
+    // ///
+    // /// This constructor allows wrapping such interfaces in a more ergonomic way,
+    // /// returning a Bytes willed using `f`.
+    // ///
+    // /// It seems it's not possible to do this as an actual `TryFrom` implementation.
+    // pub fn from_constructor<E>(
+    //     f: impl FnOnce(&mut [u8]) -> core::result::Result<usize, E>,
+    // ) -> core::result::Result<Self, E> {
     //     let mut data = Self::new();
     //     data.resize_to_capacity();
     //     let result = f(&mut data);
 
     //     result.map(|count| {
-    //         data.resize_default(count).unwrap();
+    //         data.resize_default(count)
+    //             .expect("Contructor returned size larger than capacity");
     //         data
     //     })
     // }
@@ -136,32 +201,32 @@ impl<const N: usize> Bytes<N> {
         Ok(())
     }
 
-    pub fn insert(&mut self, index: usize, item: u8) -> Result<(), u8> {
-        self.insert_slice_at(&[item], index).map_err(|_| item)
-    }
+    // pub fn insert(&mut self, index: usize, item: u8) -> Result<(), u8> {
+    //     self.insert_slice_at(&[item], index).map_err(|_| item)
+    // }
 
-    pub fn remove(&mut self, index: usize) -> Result<u8, ()> {
-        if index < self.len() {
-            unsafe { Ok(self.remove_unchecked(index)) }
-        } else {
-            Err(())
-        }
-    }
+    // pub fn remove(&mut self, index: usize) -> Result<u8, ()> {
+    //     if index < self.len() {
+    //         unsafe { Ok(self.remove_unchecked(index)) }
+    //     } else {
+    //         Err(())
+    //     }
+    // }
 
-    pub(crate) unsafe fn remove_unchecked(&mut self, index: usize) -> u8 {
-        // the place we are taking from.
-        let p = self.bytes.as_mut_ptr().add(index);
+    // pub(crate) unsafe fn remove_unchecked(&mut self, index: usize) -> u8 {
+    //     // the place we are taking from.
+    //     let p = self.bytes.as_mut_ptr().add(index);
 
-        // copy it out, unsafely having a copy of the value on
-        // the stack and in the vector at the same time.
-        let ret = ptr::read(p);
+    //     // copy it out, unsafely having a copy of the value on
+    //     // the stack and in the vector at the same time.
+    //     let ret = ptr::read(p);
 
-        // shift everything down to fill in that spot.
-        ptr::copy(p.offset(1), p, self.len() - index - 1);
+    //     // shift everything down to fill in that spot.
+    //     ptr::copy(p.offset(1), p, self.len() - index - 1);
 
-        self.resize_default(self.len() - 1).unwrap();
-        ret
-    }
+    //     self.resize_default(self.len() - 1).unwrap();
+    //     ret
+    // }
 
     pub fn resize_default(&mut self, new_len: usize) -> core::result::Result<(), ()> {
         self.bytes.resize_default(new_len)
@@ -169,6 +234,13 @@ impl<const N: usize> Bytes<N> {
 
     pub fn resize_to_capacity(&mut self) {
         self.bytes.resize_default(self.bytes.capacity()).ok();
+    }
+
+    /// Low-noise conversion between lengths.
+    ///
+    /// For an infaillible version when `M` is known to be larger than `N`, see [`increase_capacity`](Self::increase_capacity)
+    pub fn resize_capacity<const M: usize>(&self) -> Result<Bytes<M>, ()> {
+        Bytes::try_from(&**self)
     }
 
     /// Copy the contents of this `Bytes` instance into a new instance with a higher capacity.
@@ -193,33 +265,6 @@ impl<const N: usize> Bytes<N> {
         // bytes has length 0 and capacity M, self has length N, N <= M, so this can never panic
         bytes.extend_from_slice(self.as_slice()).unwrap();
         bytes.into()
-    }
-
-    /// Fallible conversion into differently sized byte buffer.
-    pub fn to_bytes<const M: usize>(&self) -> Result<Bytes<M>, ()> {
-        Bytes::<M>::from_slice(self)
-    }
-
-    #[cfg(feature = "cbor")]
-    pub fn from_serialized<T>(t: &T) -> Self
-    where
-        T: Serialize,
-    {
-        let mut vec = Vec::<u8, N>::new();
-        vec.resize_default(N).unwrap();
-        let buffer = vec.deref_mut();
-
-        let writer = serde_cbor::ser::SliceWrite::new(buffer);
-        let mut ser = serde_cbor::Serializer::new(writer)
-            .packed_format()
-            // .pack_starting_with(1)
-            // .pack_to_depth(1)
-        ;
-        t.serialize(&mut ser).unwrap();
-        let writer = ser.into_inner();
-        let size = writer.bytes_written();
-        vec.resize_default(size).unwrap();
-        Self::from(vec)
     }
 }
 
@@ -324,7 +369,7 @@ impl<const N: usize> AsMut<[u8]> for Bytes<N> {
 }
 
 impl<const N: usize> Deref for Bytes<N> {
-    type Target = Vec<u8, N>;
+    type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
         &self.bytes
@@ -336,18 +381,6 @@ impl<const N: usize> DerefMut for Bytes<N> {
         &mut self.bytes
     }
 }
-
-// impl Borrow<Bytes> for Bytes<N> {
-//     fn borrow(&self) -> &Bytes {
-//         Bytes::new(&self.bytes)
-//     }
-// }
-
-// impl BorrowMut<Bytes> for Bytes<N> {
-//     fn borrow_mut(&mut self) -> &mut Bytes {
-//         unsafe { &mut *(&mut self.bytes as &mut [u8] as *mut [u8] as *mut Bytes) }
-//     }
-// }
 
 impl<Rhs, const N: usize> PartialEq<Rhs> for Bytes<N>
 where
@@ -409,7 +442,18 @@ impl<const N: usize> Serialize for Bytes<N> {
     }
 }
 
-// TODO: can we delegate to Vec<u8, N> deserialization instead of reimplementing?
+impl<const N: usize> core::fmt::Write for Bytes<N> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.bytes.write_str(s)
+    }
+    fn write_char(&mut self, s: char) -> fmt::Result {
+        self.bytes.write_char(s)
+    }
+    fn write_fmt(&mut self, s: core::fmt::Arguments<'_>) -> fmt::Result {
+        self.bytes.write_fmt(s)
+    }
+}
+
 impl<'de, const N: usize> Deserialize<'de> for Bytes<N> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -445,6 +489,20 @@ impl<'de, const N: usize> Deserialize<'de> for Bytes<N> {
                 }
                 Ok(Bytes::<N>::from(buf))
             }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                use serde::de::Error;
+
+                let mut this = Bytes::new();
+                while let Some(byte) = seq.next_element()? {
+                    this.push(byte)
+                        .map_err(|()| A::Error::invalid_length(this.len(), &self))?;
+                }
+                Ok(this)
+            }
         }
 
         deserializer.deserialize_bytes(ValueVisitor)
@@ -466,9 +524,9 @@ mod tests_serde {
         bytes.push(1).unwrap();
         assert_tokens(&bytes, &[Token::Bytes(&[1])]);
         assert!(bytes.extend_from_slice(&[2; 16]).is_err());
-        assert_eq!(&**bytes, &[1]);
+        assert_eq!(&*bytes, &[1]);
         assert!(bytes.extend_from_slice(&[2; 15]).is_ok());
-        assert_eq!(&**bytes, &[1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]);
+        assert_eq!(&*bytes, &[1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]);
         assert_tokens(
             &bytes,
             &[Token::Bytes(&[
@@ -481,7 +539,10 @@ mod tests_serde {
     fn display() {
         assert_eq!(
             r"b'\x00abcde\n'",
-            format!("{:?}", Bytes::<10>::from_slice(b"\0abcde\n").unwrap())
+            format!(
+                "{:?}",
+                Bytes::<10>::try_from(b"\0abcde\n".as_slice()).unwrap()
+            )
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl<const N: usize> TryFrom<&[u8]> for Bytes<N> {
 impl<const N: usize> Bytes<N> {
     /// Construct a new, empty `Bytes<N>`.
     pub fn new() -> Self {
-        Self { bytes: Vec::new() }
+        Bytes::from(Vec::new())
     }
 
     pub fn as_ptr(&self) -> *const u8 {
@@ -281,78 +281,6 @@ impl<const N: usize> Bytes<N> {
     /// original order, and preserves the order of the retained elements.
     pub fn retain_mut(&mut self, f: impl FnMut(&mut u8) -> bool) {
         self.bytes.retain_mut(f)
-    }
-}
-
-impl<const N: usize> Bytes<N> {
-    // /// Some APIs offer an interface of the form `f(&mut [u8]) -> Result<usize, E>`,
-    // /// with the contract that the Ok-value signals how many bytes were written.
-    // ///
-    // /// This constructor allows wrapping such interfaces in a more ergonomic way,
-    // /// returning a Bytes willed using `f`.
-    // ///
-    // /// It seems it's not possible to do this as an actual `TryFrom` implementation.
-    // pub fn from_constructor<E>(
-    //     f: impl FnOnce(&mut [u8]) -> core::result::Result<usize, E>,
-    // ) -> core::result::Result<Self, E> {
-    //     let mut data = Self::new();
-    //     data.resize_to_capacity();
-    //     let result = f(&mut data);
-
-    //     result.map(|count| {
-    //         data.resize_default(count)
-    //             .expect("Contructor returned size larger than capacity");
-    //         data
-    //     })
-    // }
-
-    // cf. https://internals.rust-lang.org/t/add-vec-insert-slice-at-to-insert-the-content-of-a-slice-at-an-arbitrary-index/11008/3
-    pub fn insert_slice_at(&mut self, slice: &[u8], at: usize) -> core::result::Result<(), ()> {
-        let l = slice.len();
-        let before = self.len();
-
-        // make space
-        self.bytes.resize_default(before + l)?;
-
-        // move back existing
-        let raw: &mut [u8] = &mut self.bytes;
-        raw.copy_within(at..before, at + l);
-
-        // insert slice
-        raw[at..][..l].copy_from_slice(slice);
-
-        Ok(())
-    }
-
-    // pub fn insert(&mut self, index: usize, item: u8) -> Result<(), u8> {
-    //     self.insert_slice_at(&[item], index).map_err(|_| item)
-    // }
-
-    // pub fn remove(&mut self, index: usize) -> Result<u8, ()> {
-    //     if index < self.len() {
-    //         unsafe { Ok(self.remove_unchecked(index)) }
-    //     } else {
-    //         Err(())
-    //     }
-    // }
-
-    // pub(crate) unsafe fn remove_unchecked(&mut self, index: usize) -> u8 {
-    //     // the place we are taking from.
-    //     let p = self.bytes.as_mut_ptr().add(index);
-
-    //     // copy it out, unsafely having a copy of the value on
-    //     // the stack and in the vector at the same time.
-    //     let ret = ptr::read(p);
-
-    //     // shift everything down to fill in that spot.
-    //     ptr::copy(p.offset(1), p, self.len() - index - 1);
-
-    //     self.resize_default(self.len() - 1).unwrap();
-    //     ret
-    // }
-
-    pub fn resize_default(&mut self, new_len: usize) -> core::result::Result<(), ()> {
-        self.bytes.resize_default(new_len)
     }
 
     pub fn resize_to_capacity(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,6 @@
 #![cfg_attr(not(test), no_std)]
 #![allow(clippy::result_unit_err)]
 
-#[cfg(not(feature = "default"))]
-compile_error!("default features are required so that functionality can be put behind a feature flag in the future");
-
 use core::{
     cmp::Ordering,
     fmt::{self, Debug},
@@ -32,12 +29,14 @@ pub type Bytes16 = Bytes<16>;
 pub type Bytes32 = Bytes<32>;
 pub type Bytes64 = Bytes<64>;
 
+#[cfg(feature = "heapless-0.8")]
 impl<const N: usize, const M: usize> From<Vec<u8, M>> for Bytes<N> {
     fn from(vec: Vec<u8, M>) -> Self {
         Bytes { bytes: vec }.increase_capacity()
     }
 }
 
+#[cfg(feature = "heapless-0.8")]
 impl<const N: usize, const M: usize> From<Bytes<M>> for Vec<u8, N> {
     fn from(value: Bytes<M>) -> Self {
         value.increase_capacity().bytes
@@ -600,7 +599,9 @@ mod tests {
     fn from() {
         let _: Bytes<10> = [0; 10].into();
         let _: Bytes<10> = (&[0; 8]).into();
+        #[cfg(feature = "heapless-0.8")]
         let _: Bytes<10> = Vec::<u8, 10>::new().into();
+        #[cfg(feature = "heapless-0.8")]
         let _: Bytes<10> = Vec::<u8, 9>::new().into();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,29 +602,14 @@ impl<'de, const N: usize> Deserialize<'de> for Bytes<N> {
             type Value = Bytes<N>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("a sequence")
+                formatter.write_str("a sequence of bytes")
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                if v.len() > N {
-                    // hprintln!("error! own size: {}, data size: {}", N::to_usize(), v.len()).ok();
-                    // return Err(E::invalid_length(values.capacity() + 1, &self))?;
-                    return Err(E::invalid_length(v.len(), &self))?;
-                }
-                let mut buf: Vec<u8, N> = Vec::new();
-                // avoid unwrapping even though redundant
-                match buf.extend_from_slice(v) {
-                    Ok(()) => {}
-                    Err(()) => {
-                        // hprintln!("error! own size: {}, data size: {}", N::to_usize(), v.len()).ok();
-                        // return Err(E::invalid_length(values.capacity() + 1, &self))?;
-                        return Err(E::invalid_length(v.len(), &self))?;
-                    }
-                }
-                Ok(Bytes::<N>::from(buf))
+                Bytes::try_from(v).map_err(|()| E::invalid_length(v.len(), &self))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,102 +60,222 @@ impl<const N: usize> Bytes<N> {
         self.bytes.as_ptr()
     }
 
+    /// Returns a raw pointer to the vector’s buffer, which may be mutated through
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.bytes.as_mut_ptr()
     }
 
+    /// Extracts a slice containing the entire buffer.
     pub fn as_slice(&self) -> &[u8] {
         self.bytes.as_slice()
     }
+
+    /// Extracts a mutable slice containing the entire buffer.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         self.bytes.as_mut_slice()
     }
 
+    /// Get the capacity of the buffer.
+    ///
+    /// Always equal to the `N` const generic.
     pub const fn capacity(&self) -> usize {
         self.bytes.capacity()
     }
 
+    /// Clear the buffer, making it empty
     pub fn clear(&mut self) {
         self.bytes.clear()
     }
 
-    #[deprecated(note = "Panics when out of capacity")]
+    /// Extends the buffer from an iterator.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the buffer cannot hold all elements of the iterator.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Panics when out of capacity, use try_extend instead"
+    )]
     pub fn extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
         self.bytes.extend(iter)
     }
 
+    /// Extends the buffer from an iterator.
+    ///
+    /// Returns [`Err`] if out of capacity
+    pub fn try_extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) -> Result<(), ()> {
+        for b in iter {
+            self.push(b)?;
+        }
+        Ok(())
+    }
+
+    /// Extend the buffer with the contents of a slice
     pub fn extend_from_slice(&mut self, other: &[u8]) -> Result<(), ()> {
         self.bytes.extend_from_slice(other)
     }
 
+    /// Removes the last byte from the buffer and returns it, or `None` if it's empty
     pub fn pop(&mut self) -> Option<u8> {
         self.bytes.pop()
     }
 
+    /// Appends a byte to the back of the collection
     pub fn push(&mut self, byte: u8) -> Result<(), ()> {
         self.bytes.push(byte).map_err(drop)
     }
 
+    /// Removes the last byte from the buffer and returns it
+    ///
+    /// # Safety
+    ///
+    /// This assumes the buffer to have at least one element.
     pub unsafe fn pop_unchecked(&mut self) -> u8 {
         unsafe { self.bytes.pop_unchecked() }
     }
 
+    /// Appends a byte to the back of the buffer
+    ///
+    /// # Safety
+    ///
+    /// This assumes the buffer is not full.
     pub unsafe fn push_unchecked(&mut self, byte: u8) {
         unsafe {
             self.bytes.push_unchecked(byte);
         }
     }
 
+    /// Shortens the buffer, keeping the first `len` elements and dropping the rest.
     pub fn truncate(&mut self, len: usize) {
         self.bytes.truncate(len)
     }
 
+    /// Resizes the buffer in-place so that len is equal to new_len.
+    ///
+    /// If new_len is greater than len, the buffer is extended by the
+    /// difference, with each additional slot filled with `value`. If
+    /// `new_len` is less than `len`, the buffer is simply truncated.
+    ///
+    /// See also [`resize_zero`](Self::resize_zero).
     pub fn resize(&mut self, new_len: usize, value: u8) -> Result<(), ()> {
         self.bytes.resize(new_len, value)
     }
 
+    /// Resizes the buffer in-place so that len is equal to new_len.
+    ///
+    /// If new_len is greater than len, the buffer is extended by the
+    /// difference, with each additional slot filled with `0`. If
+    /// `new_len` is less than `len`, the buffer is simply truncated.
     pub fn resize_zero(&mut self, new_len: usize) -> Result<(), ()> {
         self.bytes.resize_default(new_len)
     }
 
+    /// Forces the length of the buffer to `new_len`.
+    ///
+    /// This is a low-level operation that maintains none of the normal
+    /// invariants of the type. Normally changing the length of a buffer
+    /// is done using one of the safe operations instead, such as
+    /// [`truncate`], [`resize`], [`extend`], or [`clear`].
+    ///
+    /// [`truncate`]: Self::truncate
+    /// [`resize`]: Self::resize
+    /// [`extend`]: core::iter::Extend
+    /// [`clear`]: Self::clear
+    ///
+    /// # Safety
+    ///
+    /// - `new_len` must be less than or equal to [`capacity()`].
+    /// - The elements at `old_len..new_len` must be initialized.
+    ///
+    /// [`capacity()`]: Self::capacity
+    ///
     pub unsafe fn set_len(&mut self, new_len: usize) {
         self.bytes.set_len(new_len)
     }
 
+    /// Removes a byte  from the buffer and returns it.
+    ///
+    /// The removed byte is replaced by the last byte of the vector.
+    ///
+    /// This does not preserve ordering, but is *O*(1).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
     pub fn swap_remove(&mut self, index: usize) -> u8 {
         self.bytes.swap_remove(index)
     }
 
+    /// Removes a byte  from the buffer and returns it.
+    ///
+    /// The removed byte is replaced by the last byte of the vector.
+    ///
+    /// This does not preserve ordering, but is *O*(1).
+    ///
+    /// # Safety
+    ///
+    /// `index` must not be out of bounds.
     pub unsafe fn swap_remove_unchecked(&mut self, index: usize) -> u8 {
         unsafe { self.bytes.swap_remove_unchecked(index) }
     }
 
+    /// Returns true if the buffer is full
     pub fn is_full(&self) -> bool {
         self.bytes.is_full()
     }
 
+    /// Returns true if the buffer is empty
     pub fn is_empty(&self) -> bool {
         self.bytes.is_empty()
     }
 
+    /// Returns `true` if `needle` is a prefix of the buffer.
+    ///
+    /// Always returns `true` if `needle` is an empty slice.
     pub fn starts_with(&self, needle: &[u8]) -> bool {
         self.bytes.starts_with(needle)
     }
+
+    /// Returns `true` if `needle` is a suffix of the buffer.
+    ///
+    /// Always returns `true` if `needle` is an empty slice.
     pub fn ends_with(&self, needle: &[u8]) -> bool {
         self.bytes.ends_with(needle)
     }
 
+    /// Inserts a byte at position `index` within the buffer, shifting all
+    /// bytes after it to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
     pub fn insert(&mut self, index: usize, value: u8) -> Result<(), ()> {
         self.bytes.insert(index, value).map_err(drop)
     }
 
+    /// Removes and return the byte at position `index` within the buffer, shifting all
+    /// bytes after it to the left.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
     pub fn remove(&mut self, index: usize) -> u8 {
         self.bytes.remove(index)
     }
 
+    /// Retains only the bytes specified by the predicate.
+    ///
+    /// In other words, remove all bytes `b` for which `f(&b)` returns `false`.
+    /// This method operates in place, visiting each element exactly once in the
+    /// original order, and preserves the order of the retained elements.
     pub fn retain(&mut self, f: impl FnMut(&u8) -> bool) {
         self.bytes.retain(f)
     }
+    /// Retains only the bytes specified by the predicate, passing a mutable reference to it.
+    ///
+    /// In other words, remove all bytes `b` for which `f(&mut b)` returns `false`.
+    /// This method operates in place, visiting each element exactly once in the
+    /// original order, and preserves the order of the retained elements.
     pub fn retain_mut(&mut self, f: impl FnMut(&mut u8) -> bool) {
         self.bytes.retain_mut(f)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,21 +546,3 @@ mod tests_serde {
         );
     }
 }
-
-#[cfg(test)]
-#[cfg(feature = "cbor")]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_client_data_hash() {
-        let mut minimal = [
-            0x50u8, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x30, 0x41, 0x42, 0x43,
-            0x44, 0x45, 0x46,
-        ];
-
-        let client_data_hash: Bytes<17> = serde_cbor::de::from_mut_slice(&mut minimal).unwrap();
-
-        assert_eq!(client_data_hash, b"1234567890ABCDEF");
-    }
-}


### PR DESCRIPTION
- Remove `cbor` feature
- Remove `Deref` impl to `heapless` and replace it with a impl of `Deref<Target = [u8]>`
- Remove `try_from(f: impl FnOnce(&mut [u8]) -> Result<usize, ()>` API
  AFAIK this is only used in `trussed-utils` to serialize `cbor`, which can be done through dedicated `cbor-smol` methods instead.
- Remove `insert_slice_at`
  This is only used in `fido-authenticator` to add data to the beginning of the buffer. This can easily be made in 3 lines of code without using internal APIs.
- Add `From<Bytes<N>> for Vec<u8, N>` and vice-versa
- Make `default` features required (so that we can feature-flag the `heapless` parts of the public API in the future).
- Renamed `resize_default` to `resize_zero` since we know that `Default` means `Zero` here.