### PR TITLE
Upgrade to heapless 0.9 and prepare release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [v0.5.0][] (2025-08-21)
+
+- Update `heapless` to version `0.9.1` ([#11][])
+- Add support for heapless's `View` types ([#11][])
+- Move to `serde_core` ([#11][])
+
 ## [v0.4.0][] (2024-06-20)
 
 - Update `heapless` to version `0.8` ([#3][])
@@ -9,9 +15,11 @@
 - Add conversions between `[u8; N]` and `heapless::Vec<u8, N>`. The `heapless` conversions are behind the `heapless-0.8` feature flag so that `heapless` can be bumped without a semver-breaking change in the future ([#6][] and [#8][])
 - Add `Bytes::increase_capacity` ([#6][])
 
+[v0.5.0]: https://github.com/trussed-dev/heapless-bytes/releases/tag/0.5.0
 [v0.4.0]: https://github.com/trussed-dev/heapless-bytes/releases/tag/0.4.0
 [#3]: https://github.com/trussed-dev/heapless-bytes/pull/3
 [#6]: https://github.com/trussed-dev/heapless-bytes/pull/6
 [#8]: https://github.com/trussed-dev/heapless-bytes/pull/8
+[#11]: https://github.com/trussed-dev/heapless-bytes/pull/11
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 
 [dependencies]
 heapless = { version = "0.9.1", default-features = false }
+bytes = { version = "1.10.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false }
 
 [dev-dependencies]
@@ -20,3 +21,4 @@ serde_test = "1.0.176"
 
 [features]
 "heapless-0.9" = []
+bytes = ["dep:bytes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "heapless-bytes"
-version = "0.4.0"
-authors = ["Nicolas Stalder <n@stalder.io>"]
+version = "0.5.0"
+authors = ["The Trussed developers", "Nicolas Stalder <n@stalder.io>", "Nitrokey GmbH"]
 license = "Apache-2.0 OR MIT"
 description = "Newtype around heapless byte Vec with efficient serde."
 categories = ["embedded", "encoding", "no-std"]
@@ -12,12 +12,11 @@ edition = "2021"
 
 
 [dependencies]
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9.1", default-features = false }
 serde = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0.176"
 
 [features]
-# From/Into implementation to `heapless::Vec<u8, N>`
-"heapless-0.8" = []
+"heapless-0.9" = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 heapless = { version = "0.9.1", default-features = false }
 bytes = { version = "1.10.1", default-features = false, optional = true }
-serde = { version = "1.0", default-features = false }
+serde_core = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0.176"

--- a/src/bytes_traits.rs
+++ b/src/bytes_traits.rs
@@ -1,0 +1,74 @@
+use crate::storage::BytesStorage;
+use bytes::{buf::UninitSlice, BufMut};
+use heapless::LenType;
+
+unsafe impl<S: BytesStorage + ?Sized, LenT: LenType> BufMut for crate::BytesInner<LenT, S> {
+    fn remaining_mut(&self) -> usize {
+        self.capacity() - self.len()
+    }
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        self.set_len(cnt);
+    }
+    fn chunk_mut(&mut self) -> &mut UninitSlice {
+        // SAFETY: add is safe because once the length is added is less than the buffer and therefore
+        // always in the "allocation" bounds
+        let ptr = unsafe { self.bytes.as_mut_ptr().add(self.len()) };
+        let len = self.capacity() - self.len();
+        unsafe { UninitSlice::from_raw_parts_mut(ptr, len) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Bytes, BytesView};
+    use bytes::BufMut;
+
+    #[test]
+    #[should_panic]
+    fn buf_mut_advance_mut_out_of_bounds() {
+        let mut bytes: Bytes<8> = Bytes::new();
+        unsafe { bytes.advance_mut(9) };
+    }
+
+    #[test]
+    fn buf_mut_remaining_mut() {
+        let mut bytes: Bytes<8> = Bytes::new();
+        assert_eq!(bytes.remaining_mut(), 8);
+        bytes.push(42).unwrap();
+        assert_eq!(bytes.remaining_mut(), 7);
+    }
+
+    #[test]
+    fn buf_mut_chunk_mut() {
+        let mut bytes: Bytes<8> = Bytes::new();
+        assert_eq!(bytes.chunk_mut().len(), 8);
+        unsafe { bytes.advance_mut(1) };
+        assert_eq!(bytes.chunk_mut().len(), 7);
+    }
+
+    #[test]
+    #[should_panic]
+    fn view_buf_mut_advance_mut_out_of_bounds() {
+        let mut bytes: Bytes<8> = Bytes::new();
+        let bytes: &mut BytesView = &mut bytes;
+        unsafe { bytes.advance_mut(9) };
+    }
+
+    #[test]
+    fn view_buf_mut_remaining_mut() {
+        let mut bytes: Bytes<8> = Bytes::new();
+        let bytes: &mut BytesView = &mut bytes;
+        assert_eq!(bytes.remaining_mut(), 8);
+        bytes.push(42).unwrap();
+        assert_eq!(bytes.remaining_mut(), 7);
+    }
+
+    #[test]
+    fn view_buf_mut_chunk_mut() {
+        let mut bytes: Bytes<8> = Bytes::new();
+        let bytes: &mut BytesView = &mut bytes;
+        assert_eq!(bytes.chunk_mut().len(), 8);
+        unsafe { bytes.advance_mut(1) };
+        assert_eq!(bytes.chunk_mut().len(), 7);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@
 #![cfg_attr(not(test), no_std)]
 #![allow(clippy::result_unit_err)]
 
+#[cfg(feature = "bytes")]
+mod bytes_traits;
+
 use core::{
     cmp::Ordering,
     fmt::{self, Debug},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use heapless::{
     CapacityError, LenType,
 };
 
-use serde::{
+use serde_core::{
     de::{Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
@@ -658,16 +658,16 @@ impl<'de, const N: usize, LenT: LenType> Deserialize<'de> for Bytes<N, LenT> {
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
-                E: serde::de::Error,
+                E: serde_core::de::Error,
             {
                 Bytes::try_from(v).map_err(|_: CapacityError| E::invalid_length(v.len(), &self))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
             where
-                A: serde::de::SeqAccess<'de>,
+                A: serde_core::de::SeqAccess<'de>,
             {
-                use serde::de::Error;
+                use serde_core::de::Error;
 
                 let mut this = Bytes::new();
                 while let Some(byte) = seq.next_element()? {


### PR DESCRIPTION
This PR upgrades to heapless 0.9 and introduces `View` types. It also adds a `bytes` feature to implements the traits from the `bytes` crate, as does `heapless::Vec<u8,_ , _>`.